### PR TITLE
add talk api client to get subject discussions

### DIFF
--- a/lib/panoptes-client.rb
+++ b/lib/panoptes-client.rb
@@ -1,1 +1,2 @@
 require 'panoptes/client'
+require 'panoptes/talk_client'

--- a/lib/panoptes/client.rb
+++ b/lib/panoptes/client.rb
@@ -1,8 +1,4 @@
-require 'faraday'
-require 'faraday_middleware'
-require 'faraday/panoptes'
-
-require "panoptes/client/version"
+require "panoptes/concerns/common_client"
 require "panoptes/client/me"
 require "panoptes/client/projects"
 require "panoptes/client/subjects"
@@ -17,35 +13,13 @@ module Panoptes
     class ResourceNotFound < GenericError; end
     class ServerError < GenericError; end
 
+    include Panoptes::CommonClient
     include Panoptes::Client::Me
     include Panoptes::Client::Projects
     include Panoptes::Client::Subjects
     include Panoptes::Client::SubjectSets
     include Panoptes::Client::UserGroups
     include Panoptes::Client::Workflows
-
-    # A client is the main interface to the API.
-    #
-    # @param auth [Hash] Authentication details
-    #   * either nothing,
-    #   * a hash with +:token+ (an existing OAuth user token),
-    #   * or a hash with +:client_id+ and +:client_secret+ (a keypair for an OAuth Application).
-    # @param url [String] Optional override for the API location to use. Defaults to the official production environment.
-    def initialize(auth: {}, url: "https://panoptes.zooniverse.org")
-      @conn = Faraday.new(url: url) do |faraday|
-        case
-        when auth[:token]
-          faraday.request :panoptes_access_token, url: url, access_token: auth[:token]
-        when auth[:client_id] && auth[:client_secret]
-          faraday.request :panoptes_client_credentials, url: url, client_id: auth[:client_id], client_secret: auth[:client_secret]
-        end
-
-        faraday.request :panoptes_api_v1
-        faraday.request :json
-        faraday.response :json
-        faraday.adapter Faraday.default_adapter
-      end
-    end
 
     def get(path, query = {})
       response = conn.get("/api" + path, query)

--- a/lib/panoptes/client/discussions.rb
+++ b/lib/panoptes/client/discussions.rb
@@ -1,0 +1,19 @@
+module Panoptes
+  class Client
+    module Discussions
+      # Get list of talk discussions
+      #
+      # @param focus_id [Integer] filter by focussable id
+      # @param focus_type [String] filter by focussable type
+      # @return list of discussions
+      def discussions(focus_id:, focus_type:)
+        query = {}
+        query[:focus_id] = focus_id
+        query[:focus_type] = focus_type
+
+        response = get("/discussions", query)
+        response.fetch("discussions")
+      end
+    end
+  end
+end

--- a/lib/panoptes/concerns/common_client.rb
+++ b/lib/panoptes/concerns/common_client.rb
@@ -1,0 +1,77 @@
+require 'faraday'
+require 'faraday_middleware'
+require 'faraday/panoptes'
+
+require "panoptes/client/version"
+
+module Panoptes
+  module CommonClient
+    PROD_API_URL = "https://panoptes.zooniverse.org".freeze
+    PROD_TALK_API_URL = "https://talk.zooniverse.org".freeze
+
+    # A client is the main interface to the API.
+    #
+    # @param auth [Hash] Authentication details
+    #   * either nothing,
+    #   * a hash with +:token+ (an existing OAuth user token),
+    #   * or a hash with +:client_id+ and +:client_secret+ (a keypair for an OAuth Application).
+    # @param url [String] API location to use.
+    # @param auth_url [String] Auth API location to use.
+    def initialize(auth: {}, url: PROD_API_URL, auth_url: PROD_API_URL)
+      @conn = Faraday.new(url: url) do |faraday|
+        case
+        when auth[:token]
+          faraday.request :panoptes_access_token,
+            url: auth_url,
+            access_token: auth[:token]
+        when auth[:client_id] && auth[:client_secret]
+          faraday.request :panoptes_client_credentials,
+            url: auth_url,
+            client_id: auth[:client_id],
+            client_secret: auth[:client_secret]
+        end
+
+        faraday.request :panoptes_api_v1
+        faraday.request :json
+        faraday.response :json
+        faraday.adapter Faraday.default_adapter
+      end
+    end
+
+    # Get a path and perform automatic depagination
+    def paginate(path, query, resource: nil)
+      resource = path.split("/").last if resource.nil?
+      data = last_response = get(path, query)
+
+      while next_path = last_response["meta"][resource]["next_href"]
+        last_response = get(next_path, query)
+        if block_given?
+          yield data, last_response
+        else
+          data[resource].concat(last_response[resource]) if data[resource].is_a?(Array)
+          data["meta"][resource].merge!(last_response["meta"][resource])
+          data["links"].merge!(last_response["links"])
+        end
+      end
+
+      data
+    end
+
+    private
+
+    def conn
+      @conn
+    end
+
+    def handle_response(response)
+      case response.status
+      when 404
+        raise ResourceNotFound, status: response.status, body: response.body
+      when 400..600
+        raise ServerError.new(response.body)
+      else
+        response.body
+      end
+    end
+  end
+end

--- a/lib/panoptes/talk_client.rb
+++ b/lib/panoptes/talk_client.rb
@@ -1,0 +1,64 @@
+require 'faraday'
+require 'faraday_middleware'
+require 'faraday/panoptes'
+
+require "panoptes/client/version"
+require "panoptes/client/discussions"
+
+module Panoptes
+  class TalkClient
+    include Panoptes::Client::Discussions
+
+    # A client is the main interface to the talk v2 API.
+    # @param url [String] Optional override for the API location to use. Defaults to the official production environment.
+    def initialize(url: "https://talk.zooniverse.org")
+      @conn = Faraday.new(url: url) do |faraday|
+        faraday.request :panoptes_api_v1
+        faraday.request :json
+        faraday.response :json
+        faraday.adapter Faraday.default_adapter
+      end
+    end
+
+    def get(path, query = {})
+      response = conn.get(path, query)
+      handle_response(response)
+    end
+
+    # Get a path and perform automatic depagination
+    def paginate(path, query, resource: nil)
+      resource = path.split("/").last if resource.nil?
+      data = last_response = get(path, query)
+
+      while next_path = last_response["meta"][resource]["next_href"]
+        last_response = get(next_path, query)
+        if block_given?
+          yield data, last_response
+        else
+          data[resource].concat(last_response[resource]) if data[resource].is_a?(Array)
+          data["meta"][resource].merge!(last_response["meta"][resource])
+          data["links"].merge!(last_response["links"])
+        end
+      end
+
+      data
+    end
+
+    private
+
+    def conn
+      @conn
+    end
+
+    def handle_response(response)
+      case response.status
+      when 404
+        raise ResourceNotFound, status: response.status, body: response.body
+      when 400..600
+        raise ServerError.new(response.body)
+      else
+        response.body
+      end
+    end
+  end
+end

--- a/lib/panoptes/talk_client.rb
+++ b/lib/panoptes/talk_client.rb
@@ -1,64 +1,25 @@
-require 'faraday'
-require 'faraday_middleware'
-require 'faraday/panoptes'
-
-require "panoptes/client/version"
+require "panoptes/concerns/common_client"
 require "panoptes/client/discussions"
 
 module Panoptes
   class TalkClient
+    include Panoptes::CommonClient
     include Panoptes::Client::Discussions
 
+    # @param auth [Hash] Authentication details
+    #   * either nothing,
+    #   * a hash with +:token+ (an existing OAuth user token),
+    #   * or a hash with +:client_id+ and +:client_secret+ (a keypair for an OAuth Application).
     # A client is the main interface to the talk v2 API.
-    # @param url [String] Optional override for the API location to use. Defaults to the official production environment.
-    def initialize(url: "https://talk.zooniverse.org")
-      @conn = Faraday.new(url: url) do |faraday|
-        faraday.request :panoptes_api_v1
-        faraday.request :json
-        faraday.response :json
-        faraday.adapter Faraday.default_adapter
-      end
+    # @param url [String] Optional override for the API location to use. Defaults to the official talk api production environment.
+    # @param auth_url [String] Optional override for the auth API location to use. Defaults to the official api production environment.
+    def initialize(auth: {}, url: PROD_TALK_API_URL, auth_url: PROD_API_URL)
+      super(auth: auth, url: url, auth_url: auth_url)
     end
 
     def get(path, query = {})
       response = conn.get(path, query)
       handle_response(response)
-    end
-
-    # Get a path and perform automatic depagination
-    def paginate(path, query, resource: nil)
-      resource = path.split("/").last if resource.nil?
-      data = last_response = get(path, query)
-
-      while next_path = last_response["meta"][resource]["next_href"]
-        last_response = get(next_path, query)
-        if block_given?
-          yield data, last_response
-        else
-          data[resource].concat(last_response[resource]) if data[resource].is_a?(Array)
-          data["meta"][resource].merge!(last_response["meta"][resource])
-          data["links"].merge!(last_response["links"])
-        end
-      end
-
-      data
-    end
-
-    private
-
-    def conn
-      @conn
-    end
-
-    def handle_response(response)
-      case response.status
-      when 404
-        raise ResourceNotFound, status: response.status, body: response.body
-      when 400..600
-        raise ServerError.new(response.body)
-      else
-        response.body
-      end
     end
   end
 end

--- a/spec/fixtures/vcr/Panoptes_Client_Discussions/_discussions/returns_a_list_of_discussions_for_a_given_focus_id_type.yml
+++ b/spec/fixtures/vcr/Panoptes_Client_Discussions/_discussions/returns_a_list_of_discussions_for_a_given_focus_id_type.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://talk-staging.zooniverse.org/discussions?focus_id=35472&focus_type=Subject
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - application/vnd.api+json; version=1
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 21 Jun 2016 10:57:34 GMT
+      Etag:
+      - W/"c3fe4aa5ea97c18255291a280fa87a9a"
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 60d84fc3-0fa2-4166-9030-243d222d9610
+      X-Runtime:
+      - '0.113613'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '11010'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"discussions":[{"href":"/discussions/55","links":{},"board_id":"42","comments_count":12,"created_at":"2015-06-26T05:33:47.295Z","focus_id":"35472","focus_type":"Subject","id":"55","last_comment_created_at":"2015-12-14T15:49:33.021Z","locked":false,"project_id":"604","section":"project-604","sticky":false,"sticky_position":null,"subject_default":true,"title":"Subject
+        35472","updated_at":"2015-12-14T15:49:33.100Z","user_id":"1323827","user_login":"chrissnyder-panoptes","users_count":4,"latest_comment":{"href":"/comments/700","links":{},"board_id":"42","body":"hello","category":null,"created_at":"2015-12-14T15:49:33.021Z","discussion_id":"55","focus_id":"35472","focus_type":"Subject","group_mentioning":{},"id":"700","is_deleted":false,"mentioning":{},"project_id":"604","reply_id":"","section":"project-604","tagging":{},"updated_at":"2015-12-14T15:49:33.021Z","upvotes":{},"user_id":"288433","user_login":"alex-panoptes","versions":[],"reply_user_id":null,"reply_user_login":null,"reply_user_display_name":null,"discussion_comments_count":12,"discussion_subject_default":true,"discussion_title":"Subject
+        35472","discussion_updated_at":"2015-12-14T15:49:33.100Z","discussion_users_count":4,"discussion_focus_id":"35472","discussion_focus_type":"Subject","discussion_locked":false,"board_comments_count":82,"board_description":"General
+        comment threads about individual subjects","board_discussions_count":4,"board_parent_id":"","board_subject_default":true,"board_title":"Notes","board_users_count":8,"board_permissions":{"read":"all","write":"all"},"project_slug":"alex-panoptes/test-proj","moderatable_actions":[],"user_display_name":"alex-panoptes"},"project_slug":"alex-panoptes/test-proj","board_comments_count":82,"board_description":"General
+        comment threads about individual subjects","board_discussions_count":4,"board_parent_id":"","board_subject_default":true,"board_title":"Notes","board_users_count":8,"board_permissions":{"read":"all","write":"all"},"moderatable_actions":[],"user_display_name":"chrissnyder-ouroboros"},{"href":"/discussions/134","links":{},"board_id":"21","comments_count":1,"created_at":"2015-12-12T19:03:46.151Z","focus_id":"35472","focus_type":"Subject","id":"134","last_comment_created_at":"2015-12-12T19:03:46.151Z","locked":false,"project_id":"604","section":"project-604","sticky":false,"sticky_position":null,"subject_default":false,"title":"hello","updated_at":"2015-12-12T19:03:46.284Z","user_id":"288433","user_login":"alex-panoptes","users_count":1,"latest_comment":{"href":"/comments/695","links":{},"board_id":"21","body":"asdasd","category":null,"created_at":"2015-12-12T19:03:46.170Z","discussion_id":"134","focus_id":"35472","focus_type":"Subject","group_mentioning":{},"id":"695","is_deleted":false,"mentioning":{},"project_id":"604","reply_id":"","section":"project-604","tagging":{},"updated_at":"2015-12-12T19:03:46.170Z","upvotes":{},"user_id":"288433","user_login":"alex-panoptes","versions":[],"reply_user_id":null,"reply_user_login":null,"reply_user_display_name":null,"discussion_comments_count":1,"discussion_subject_default":false,"discussion_title":"hello","discussion_updated_at":"2015-12-12T19:03:46.284Z","discussion_users_count":1,"discussion_focus_id":"35472","discussion_focus_type":"Subject","discussion_locked":false,"board_comments_count":70,"board_description":"Fireworks","board_discussions_count":17,"board_parent_id":"","board_subject_default":false,"board_title":"Thank
+        me later","board_users_count":6,"board_permissions":{"read":"all","write":"all"},"project_slug":"alex-panoptes/test-proj","moderatable_actions":[],"user_display_name":"alex-panoptes"},"project_slug":"alex-panoptes/test-proj","board_comments_count":70,"board_description":"Fireworks","board_discussions_count":17,"board_parent_id":"","board_subject_default":false,"board_title":"Thank
+        me later","board_users_count":6,"board_permissions":{"read":"all","write":"all"},"moderatable_actions":[],"user_display_name":"alex-panoptes"},{"href":"/discussions/127","links":{},"board_id":"21","comments_count":1,"created_at":"2015-10-23T21:06:03.314Z","focus_id":"35472","focus_type":"Subject","id":"127","last_comment_created_at":"2015-10-23T21:06:03.314Z","locked":false,"project_id":"604","section":"project-604","sticky":false,"sticky_position":null,"subject_default":false,"title":"New
+        discussion test","updated_at":"2015-10-23T21:06:03.447Z","user_id":"288433","user_login":"alex-panoptes","users_count":1,"latest_comment":{"href":"/comments/667","links":{},"board_id":"21","body":"Alex","category":null,"created_at":"2015-10-23T21:06:03.327Z","discussion_id":"127","focus_id":"35472","focus_type":"Subject","group_mentioning":{},"id":"667","is_deleted":false,"mentioning":{},"project_id":"604","reply_id":"","section":"project-604","tagging":{},"updated_at":"2015-10-23T21:06:03.327Z","upvotes":{},"user_id":"288433","user_login":"alex-panoptes","versions":[],"reply_user_id":null,"reply_user_login":null,"reply_user_display_name":null,"discussion_comments_count":1,"discussion_subject_default":false,"discussion_title":"New
+        discussion test","discussion_updated_at":"2015-10-23T21:06:03.447Z","discussion_users_count":1,"discussion_focus_id":"35472","discussion_focus_type":"Subject","discussion_locked":false,"board_comments_count":70,"board_description":"Fireworks","board_discussions_count":17,"board_parent_id":"","board_subject_default":false,"board_title":"Thank
+        me later","board_users_count":6,"board_permissions":{"read":"all","write":"all"},"project_slug":"alex-panoptes/test-proj","moderatable_actions":[],"user_display_name":"alex-panoptes"},"project_slug":"alex-panoptes/test-proj","board_comments_count":70,"board_description":"Fireworks","board_discussions_count":17,"board_parent_id":"","board_subject_default":false,"board_title":"Thank
+        me later","board_users_count":6,"board_permissions":{"read":"all","write":"all"},"moderatable_actions":[],"user_display_name":"alex-panoptes"},{"href":"/discussions/80","links":{},"board_id":"21","comments_count":5,"created_at":"2015-07-24T19:28:21.501Z","focus_id":"35472","focus_type":"Subject","id":"80","last_comment_created_at":"2015-08-26T17:22:32.405Z","locked":false,"project_id":"604","section":"project-604","sticky":false,"sticky_position":null,"subject_default":false,"title":"Test
+        discussion","updated_at":"2015-08-26T17:22:32.610Z","user_id":"95","user_login":"alex4","users_count":3,"latest_comment":{"href":"/comments/467","links":{},"board_id":"21","body":"^S123123","category":null,"created_at":"2015-08-26T17:22:32.405Z","discussion_id":"80","focus_id":"35472","focus_type":"Subject","group_mentioning":{},"id":"467","is_deleted":false,"mentioning":{},"project_id":"604","reply_id":"","section":"project-604","tagging":{},"updated_at":"2015-08-26T17:22:32.405Z","upvotes":{},"user_id":"288433","user_login":"alex-panoptes","versions":[],"reply_user_id":null,"reply_user_login":null,"reply_user_display_name":null,"discussion_comments_count":5,"discussion_subject_default":false,"discussion_title":"Test
+        discussion","discussion_updated_at":"2015-08-26T17:22:32.610Z","discussion_users_count":3,"discussion_focus_id":"35472","discussion_focus_type":"Subject","discussion_locked":false,"board_comments_count":70,"board_description":"Fireworks","board_discussions_count":17,"board_parent_id":"","board_subject_default":false,"board_title":"Thank
+        me later","board_users_count":6,"board_permissions":{"read":"all","write":"all"},"project_slug":"alex-panoptes/test-proj","moderatable_actions":[],"user_display_name":"alex-panoptes"},"project_slug":"alex-panoptes/test-proj","board_comments_count":70,"board_description":"Fireworks","board_discussions_count":17,"board_parent_id":"","board_subject_default":false,"board_title":"Thank
+        me later","board_users_count":6,"board_permissions":{"read":"all","write":"all"},"moderatable_actions":[],"user_display_name":"alex4"},{"href":"/discussions/56","links":{},"board_id":"21","comments_count":5,"created_at":"2015-06-26T05:40:01.040Z","focus_id":"35472","focus_type":"Subject","id":"56","last_comment_created_at":"2015-06-29T19:38:40.429Z","locked":false,"project_id":"604","section":"project-604","sticky":false,"sticky_position":null,"subject_default":false,"title":"not
+        in notes discussion","updated_at":"2015-08-13T20:47:29.634Z","user_id":"1323827","user_login":"chrissnyder-panoptes","users_count":2,"latest_comment":{"href":"/comments/148","links":{},"board_id":"21","body":"\u003e
+        In reply to alex-panoptes''s comment: \n\u003e \u003e In reply to alex-panoptes''s
+        comment: \n\u003e \u003e \u003e In reply to alex-panoptes''s comment: \n\u003e
+        \u003e \u003e \u003e In reply to alex-panoptes''s comment: \n\u003e \u003e
+        \u003e \u003e \u003e In reply to chrissnyder-panoptes''s comment: \n\u003e
+        \u003e \u003e \u003e \u003e hello!\n\u003e \u003e \u003e \u003e \n\u003e \u003e
+        \u003e \u003e testing out quotes\n\u003e \u003e \u003e \n\u003e \u003e \u003e
+        testing out quotes\n\u003e \u003e \n\u003e \u003e Testing out quotes\n\u003e
+        \n\u003e Hey\n\nTest nest","category":null,"created_at":"2015-06-29T19:38:40.429Z","discussion_id":"56","focus_id":"35472","focus_type":"Subject","group_mentioning":{},"id":"148","is_deleted":false,"mentioning":{},"project_id":"604","reply_id":"","section":"project-604","tagging":{},"updated_at":"2015-06-29T19:38:40.429Z","upvotes":{},"user_id":"288433","user_login":"alex-panoptes","versions":[],"reply_user_id":null,"reply_user_login":null,"reply_user_display_name":null,"discussion_comments_count":5,"discussion_subject_default":false,"discussion_title":"not
+        in notes discussion","discussion_updated_at":"2015-08-13T20:47:29.634Z","discussion_users_count":2,"discussion_focus_id":"35472","discussion_focus_type":"Subject","discussion_locked":false,"board_comments_count":70,"board_description":"Fireworks","board_discussions_count":17,"board_parent_id":"","board_subject_default":false,"board_title":"Thank
+        me later","board_users_count":6,"board_permissions":{"read":"all","write":"all"},"project_slug":"alex-panoptes/test-proj","moderatable_actions":[],"user_display_name":"alex-panoptes"},"project_slug":"alex-panoptes/test-proj","board_comments_count":70,"board_description":"Fireworks","board_discussions_count":17,"board_parent_id":"","board_subject_default":false,"board_title":"Thank
+        me later","board_users_count":6,"board_permissions":{"read":"all","write":"all"},"moderatable_actions":[],"user_display_name":"chrissnyder-ouroboros"}],"meta":{"discussions":{"page":1,"page_size":10,"count":5,"include":[],"page_count":1,"previous_page":null,"next_page":null,"first_href":"/discussions?sort=-sticky,sticky_position,-last_comment_created_at\u0026focus_id=35472","previous_href":null,"next_href":null,"last_href":"/discussions?sort=-sticky,sticky_position,-last_comment_created_at\u0026focus_id=35472","current_sort":"-sticky,sticky_position,-last_comment_created_at","default_sort":"-sticky,sticky_position,-last_comment_created_at","sortable_attributes":["last_comment_created_at","sticky","sticky_position"]}}}'
+    http_version: 
+  recorded_at: Tue, 21 Jun 2016 10:57:34 GMT
+recorded_with: VCR 3.0.1

--- a/spec/panoptes/client/discussions_spec.rb
+++ b/spec/panoptes/client/discussions_spec.rb
@@ -1,15 +1,16 @@
 require 'spec_helper'
 
 describe Panoptes::Client::Discussions, :vcr do
-  describe '#discussions' do
+  describe "#discussions" do
     let(:client) { talk_client }
     let(:id) { 35472 }
     let(:type) { "Subject" }
 
-    it 'returns a list of discussions for a given focus id & type' do
+    it "returns a list of discussions for a given focus id & type" do
       discussions = client.discussions(focus_id: id, focus_type: type)
       expect(discussions.size).to eq(5)
-      assert_requested :get, talk_api_url("/discussions?focus_id=#{id}&focus_type=#{type}")
+      expected_url = talk_api_url("/discussions?focus_id=#{id}&focus_type=#{type}")
+      assert_requested :get, expected_url
     end
   end
 end

--- a/spec/panoptes/client/discussions_spec.rb
+++ b/spec/panoptes/client/discussions_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Panoptes::Client::Discussions, :vcr do
+  describe '#discussions' do
+    let(:client) { talk_client }
+    let(:id) { 35472 }
+    let(:type) { "Subject" }
+
+    it 'returns a list of discussions for a given focus id & type' do
+      discussions = client.discussions(focus_id: id, focus_type: type)
+      expect(discussions.size).to eq(5)
+      assert_requested :get, talk_api_url("/discussions?focus_id=#{id}&focus_type=#{type}")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,11 +27,19 @@ def unauthenticated_client
 end
 
 def application_client
-  Panoptes::Client.new(url: test_url, auth: {client_id: test_client_id, client_secret: test_client_secret})
+  Panoptes::Client.new(
+    url: test_url,
+    auth_url: test_url,
+    auth: { client_id: test_client_id, client_secret: test_client_secret }
+  )
 end
 
 def user_client
-  Panoptes::Client.new(url: test_url, auth: {token: test_access_token})
+  Panoptes::Client.new(
+    url: test_url,
+    auth_url: test_url,
+    auth: { token: test_access_token }
+  )
 end
 
 def talk_client

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ VCR.configure do |config|
 end
 
 def test_url;           ENV.fetch("ZOONIVERSE_URL",           'https://panoptes-staging.zooniverse.org'); end
+def test_talk_url;      ENV.fetch("ZOONIVERSE_TALK_URL",      'https://talk-staging.zooniverse.org'); end
 def test_access_token;  ENV.fetch("ZOONIVERSE_ACCESS_TOKEN",  'x'*64); end
 def test_client_id;     ENV.fetch("ZOONIVERSE_CLIENT_ID",     'x'*64); end
 def test_client_secret; ENV.fetch("ZOONIVERSE_CLIENT_SECRET", 'x'*64); end
@@ -33,6 +34,14 @@ def user_client
   Panoptes::Client.new(url: test_url, auth: {token: test_access_token})
 end
 
+def talk_client
+  Panoptes::TalkClient.new(url: test_talk_url)
+end
+
 def api_url(path)
   test_url + "/api" + path
+end
+
+def talk_api_url(path)
+  test_talk_url + path
 end


### PR DESCRIPTION
Linked to https://github.com/zooniverse/Panoptes/pull/1833 

Add the panoptes talk client to find subjects with discussions. I'd like to refactor the panoptes client base functionality with composition but wanted to get a first pass by @marten for comments. 