### PR TITLE
require new version of faraday-panoptes

### DIFF
--- a/lib/panoptes/client/version.rb
+++ b/lib/panoptes/client/version.rb
@@ -1,5 +1,5 @@
 module Panoptes
   class Client
-    VERSION = "0.2.13".freeze
+    VERSION = "0.3.0".freeze
   end
 end

--- a/panoptes-client.gemspec
+++ b/panoptes-client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday"
-  spec.add_dependency "faraday-panoptes", "~> 0.2.0"
+  spec.add_dependency "faraday-panoptes", "~> 0.3.0"
   spec.add_dependency "jwt", "~> 1.5.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
faraday-panoptes-0.3.0 will report a more sensible error if your credentials are invalid.