### PR TITLE
bump to v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.0.0
 
 * Refactor of authentication code public interface
+* Remove deprecated `current_user` method
 * Stable API release
 
 # 0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.0
+
+* Refactor of authentication code public interface
+* Stable API release
+
 # 0.4.0
 
 * Additional methods for interacting with JWT

--- a/lib/panoptes/client/authentication.rb
+++ b/lib/panoptes/client/authentication.rb
@@ -55,11 +55,6 @@ module Panoptes
         token_contents.fetch('admin', false)
       end
 
-      def current_user
-        token_contents
-      end
-      deprecate :current_user, :token_contents, 2019, 7
-
       private
 
       def ensure_authenticated

--- a/lib/panoptes/client/version.rb
+++ b/lib/panoptes/client/version.rb
@@ -2,6 +2,6 @@
 
 module Panoptes
   class Client
-    VERSION = '1.0.0'.freeze
+    VERSION = '1.0.0-pre1'.freeze
   end
 end

--- a/lib/panoptes/client/version.rb
+++ b/lib/panoptes/client/version.rb
@@ -2,6 +2,6 @@
 
 module Panoptes
   class Client
-    VERSION = '1.0.0-pre1'.freeze
+    VERSION = '1.0.0'.freeze
   end
 end

--- a/lib/panoptes/client/version.rb
+++ b/lib/panoptes/client/version.rb
@@ -2,6 +2,6 @@
 
 module Panoptes
   class Client
-    VERSION = '0.4.0'
+    VERSION = '1.0.0'.freeze
   end
 end

--- a/lib/panoptes/client/version.rb
+++ b/lib/panoptes/client/version.rb
@@ -2,6 +2,6 @@
 
 module Panoptes
   class Client
-    VERSION = '1.0.0'.freeze
+    VERSION = '1.0.0'
   end
 end

--- a/spec/panoptes/client/authentication_spec.rb
+++ b/spec/panoptes/client/authentication_spec.rb
@@ -197,23 +197,5 @@ describe Panoptes::Client::Authentication do
         expect(client).to have_received(:token_contents).twice
       end
     end
-
-    describe 'current_user' do
-      let(:client) do
-        user_client
-      end
-
-      it 'is the same as token contents' do
-        payload_data = { 'id' => 1, 'admin' => true }
-        allow(client).to receive(:token_contents).and_return(payload_data)
-        expect(client.current_user).to eq(payload_data)
-        expect(client).to have_received(:token_contents).once
-      end
-    end
-
-    it 'raises when not logged in' do
-      client = unauthenticated_client
-      expect { client.token_contents }.to raise_error(Panoptes::Client::NotLoggedIn)
-    end
   end
 end


### PR DESCRIPTION
The API in this gem is stable now so we should cut a v1.0.0 release. 

I don't think i've modified the public API in downstream clients via #28, however i'd like to avoid breaking downstream apps by doing a minor version bump. To avoid that, this is a major bump and we will need to update downstream clients to test the public API updates before these are automatically included on build