### PR TITLE
Update dev env and add GH Actions CI test runner

### DIFF
--- a/.github/workflows/run_tests_CI.yml
+++ b/.github/workflows/run_tests_CI.yml
@@ -1,0 +1,17 @@
+name: Zooni CI
+on:
+  pull_request:
+  push: { branches: master }
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-cache: bundler
-rvm:
-  - 2.4
-  - 2.5
-  - 2.6
-before_install: gem install bundler -v 1.11.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ruby:2.7-slim
+
+WORKDIR /panoptes-client
+
+RUN apt-get update && apt-get -y upgrade && \
+    apt-get install --no-install-recommends -y \
+        build-essential \
+        # git is required for installing gems from git repos
+        git \
+        nano \
+        vim
+
+ADD ./Gemfile /panoptes-client/
+ADD ./panoptes-client.gemspec /panoptes-client/
+ADD ./lib/panoptes/client/version.rb /panoptes-client/lib/panoptes/client/
+ADD .git/ /panoptes-client/
+
+RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1` && bundle install
+
+ADD ./ /panoptes-client
+
+CMD ["bundle", "exec", "rspec"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ In general, this library is supposed to be a thin, flat layer over our [HTTP-bas
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
+Alternatively use docker and docker-compose to get your dev env setup.
+
+``` bash
+docker-compose build # to build your dev docker image
+docker-compose up # to run the tests in the dev container
+
+# or run an interactive bash session in the dev container
+docker-compose run --service-ports --rm panoptes-client bash
+```
+
 The test suite uses VCR to record HTTP requests, so if you're not making any new requests you should be fine with the existing cassettes. If you are, the test suite uses environment variables to pull in authentication credentials. You'll need to [create an OAuth application on staging](https://panoptes-staging.zooniverse.org/oauth/applications), and set the following env vars:
 
 | Variable                   | Value |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  panoptes-client:
+    build:
+      context: .
+    volumes:
+      - ./:/panoptes-client
+      - gem_cache:/usr/local/bundle
+
+volumes:
+  gem_cache:

--- a/panoptes-client.gemspec
+++ b/panoptes-client.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday-panoptes', '~> 0.3.0'
   spec.add_dependency 'jwt', '~> 1.5.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'timecop', '~> 0.8.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'timecop'
   spec.add_development_dependency 'yard'
 end


### PR DESCRIPTION
This PR adds a dockerized development env for local dev and testing using docker and docker-compose. It also adds a GH Actions CI test runner and removes the old travis CI integration. 

Finally this PR removes the dev dependency version restrictions and instead allows bundler to sort out what version we need. Long term we can lock these down if we need but they are working with the latest versions as of this PR change. 