### PR TITLE
allow faraday panoptes to bump past v0.3

### DIFF
--- a/panoptes-client.gemspec
+++ b/panoptes-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'deprecate'
   spec.add_dependency 'faraday'
-  spec.add_dependency 'faraday-panoptes', '~> 0.3.0'
+  spec.add_dependency 'faraday-panoptes', '~> 0.3'
   spec.add_dependency 'jwt', '~> 1.5.0'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
relax the `faraday-panoptes` gem patch version constraint to allow minor version changes, specifically > 0.3 and < 1.0